### PR TITLE
9 update readme maintainership

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,12 @@ Description: A set of tools for processing and analyzing in vitro toxicokinetic
              oral absorption (Caco2). The methods provided
              by the package were described in Wambaugh et al. (2019) <doi:10.1093/toxsci/kfz205>.
 Authors@R: c(
-           person("John", "Wambaugh", email = "wambaugh.john@epa.gov", 
+           person("John", "Wambaugh", 
              role = c("aut"),comment = c(ORCID = "0000-0002-4024-534X")), 
+           person("Caroline", "Ring", email = "ring.caroline@epa.gov",
+             role = c("cre"), comment = c(ORCID = "0000-0002-0463-1251")),
            person("Sarah E.", "Davidson-Fritz", email = "davidsonfritz.sarah@epa.gov", 
-             role = c("aut","cre"), comment = c(ORCID = "0000-0002-2891-9380")),
+             role = c("aut"), comment = c(ORCID = "0000-0002-2891-9380")),
            person("Lindsay","Knupp",role = c("ctb")),
            person("Barbara A.","Wetmore",role = c("ctb"),
             comment = c(ORCID = "0000-0002-6878-5348")),
@@ -45,6 +47,6 @@ Encoding: UTF-8
 VignetteBuilder: knitr, R.rsp
 RoxygenNote: 7.3.2
 NeedsCompilation: no
-Maintainer: Sarah E. Davidson-Fritz <davidsonfritz.sarah@epa.gov>
+Maintainer: Caroline Ring <ring.caroline@epa.gov>
 URL: https://github.com/USEPA/invitroTKstats
 BugReports: https://github.com/USEPA/invitroTKstats/issues

--- a/R/merge_level0.R
+++ b/R/merge_level0.R
@@ -208,7 +208,7 @@
 #'                           peak = "Area...13",
 #'                           istd.peak = "Resp....16",
 #'                           conc = "Final Conc....11",
-#'                           analysis.param = "Exp. Conc....10",
+#'                           analysis.param = "RT...12",
 #'                           col.names.loc = 2)
 #' # Create chem.ids data.frame
 #' chem.ids <- data.frame("Chem.Lab.ID" = "745",

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,10 +17,10 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
-[![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats) 
+[![Active](https://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats) 
 [![Monthly Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
-[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
+[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](https://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
 <!-- badges: end -->
 
 ## Welcome to the GitHub repository for the invitroTKstats package
@@ -104,10 +104,10 @@ A subset of raw experimental data files are provided as part of the R package fo
 ## Contributors
 
 * Caroline Ring (Lead Package Developer & Maintainer)
-* John Wambaugh (Package Creator, Conceptualization, Data Processing, & Subject Matter Expert)
-* Sarah E. Davidson-Fritz (Conceptualization & Software Development)
-* Lindsay Knupp (Software Development)
 * Barbara A. Wetmore (Raw Data Generation & Subject Matter Expert)
+* Sarah E. Davidson-Fritz (Conceptualization & Software Development)
+* John Wambaugh (Package Creator, Conceptualization, Data Processing, & Subject Matter Expert)
+* Lindsay Knupp (Software Development)
 * Nicolas Chantel (Initial Bayesian Model Development for $f_{up}$ RED assay)
 * Zhihui Zhao (Software Development)
 * Anna Kreutz (Raw Data Generation & Subject Matter Expert)

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,12 +15,15 @@ knitr::opts_chunk$set(
 
 # invitroTKstats
 
-<!-- badges: start -->
-<!-- badges: end -->
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
+[![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats) 
+[![Monthly Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)
+[![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
+[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
 
 ## Welcome to the GitHub repository for the invitroTKstats package
 
-<a href="https://github.com/USEPA/invitroTKstats"><img src="vignettes/img/invitroTKstats_hex.png" width="200" align="right" /></a>
+<a href="https://cran.r-project.org/web/packages/invitroTKstats/index.html"><img src="vignettes/img/invitroTKstats_hex.png" width="200" align="right" /></a>
 
 The `invitroTKstats` R package contains functions to run a standardized data pipeline for processing high-throughput toxicokinetic (HTTK) mass-spectrometry data obtained from a variety of *in vitro* assays. The pipeline includes standardization for data documentation, statistical analyses predicting toxicokinetic parameters characterizing absorption, distribution, metabolism, and elimination of chemicals by the body.
 
@@ -98,8 +101,9 @@ A subset of raw experimental data files are provided as part of the R package fo
 
 ## Contributors
 
+* Caroline Ring (Lead Package Developer & Maintainer)
 * John Wambaugh (Package Creator, Conceptualization, Data Processing, & Subject Matter Expert)
-* Sarah E. Davidson-Fritz (Conceptualization & Lead Package Developer)
+* Sarah E. Davidson-Fritz (Conceptualization & Software Development)
 * Lindsay Knupp (Software Development)
 * Barbara A. Wetmore (Raw Data Generation & Subject Matter Expert)
 * Nicolas Chantel (Initial Bayesian Model Development for $f_{up}$ RED assay)

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,11 +15,13 @@ knitr::opts_chunk$set(
 
 # invitroTKstats
 
+<!-- badges: start -->
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
 [![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats) 
 [![Monthly Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
 [![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
+<!-- badges: end -->
 
 ## Welcome to the GitHub repository for the invitroTKstats package
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,17 @@
 
 # invitroTKstats
 
-<!-- badges: start -->
-
-<!-- badges: end -->
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
+[![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats)
+[![Monthly
+Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)
+[![Total
+Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
+[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
 
 ## Welcome to the GitHub repository for the invitroTKstats package
 
-<a href="https://github.com/USEPA/invitroTKstats"><img src="vignettes/img/invitroTKstats_hex.png" width="200" align="right" /></a>
+<a href="https://cran.r-project.org/web/packages/invitroTKstats/index.html"><img src="vignettes/img/invitroTKstats_hex.png" width="200" align="right" /></a>
 
 The `invitroTKstats` R package contains functions to run a standardized
 data pipeline for processing high-throughput toxicokinetic (HTTK)
@@ -129,9 +133,10 @@ under “working/KreutzPFAS”.
 
 ## Contributors
 
+- Caroline Ring (Lead Package Developer & Maintainer)
 - John Wambaugh (Package Creator, Conceptualization, Data Processing, &
   Subject Matter Expert)
-- Sarah E. Davidson-Fritz (Conceptualization & Lead Package Developer)
+- Sarah E. Davidson-Fritz (Conceptualization & Software Development)
 - Lindsay Knupp (Software Development)
 - Barbara A. Wetmore (Raw Data Generation & Subject Matter Expert)
 - Nicolas Chantel (Initial Bayesian Model Development for $f_{up}$ RED

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 <!-- badges: start -->
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
-[![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats)
+[![Active](https://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats)
 [![Monthly
 Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BAFD4)
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
-[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
+[![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](https://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
 <!-- badges: end -->
 
 ## Welcome to the GitHub repository for the invitroTKstats package
@@ -137,11 +137,11 @@ under “working/KreutzPFAS”.
 ## Contributors
 
 - Caroline Ring (Lead Package Developer & Maintainer)
+- Barbara A. Wetmore (Raw Data Generation & Subject Matter Expert)
+- Sarah E. Davidson-Fritz (Conceptualization & Software Development)
 - John Wambaugh (Package Creator, Conceptualization, Data Processing, &
   Subject Matter Expert)
-- Sarah E. Davidson-Fritz (Conceptualization & Software Development)
 - Lindsay Knupp (Software Development)
-- Barbara A. Wetmore (Raw Data Generation & Subject Matter Expert)
 - Nicolas Chantel (Initial Bayesian Model Development for $f_{up}$ RED
   assay)
 - Zhihui Zhao (Software Development)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # invitroTKstats
 
+<!-- badges: start -->
+
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
 [![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://cran.r-project.org/package=invitroTKstats)
 [![Monthly
@@ -10,6 +12,7 @@ Downloads](https://cranlogs.r-pkg.org/badges/last-month/invitroTKstats?color=7BA
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/invitroTKstats)](https://cran.r-project.org/package=invitroTKstats)
 [![DOI](https://zenodo.org/badge/doi/10.32614/CRAN.package.invitroTKstats.svg)](http://dx.doi.org/10.32614/CRAN.package.invitroTKstats)
+<!-- badges: end -->
 
 ## Welcome to the GitHub repository for the invitroTKstats package
 

--- a/man/merge_level0.Rd
+++ b/man/merge_level0.Rd
@@ -255,7 +255,7 @@ catalog <- create_catalog(file = "Hep_745_949_959_082421_final.xlsx",
                           peak = "Area...13",
                           istd.peak = "Resp....16",
                           conc = "Final Conc....11",
-                          analysis.param = "Exp. Conc....10",
+                          analysis.param = "RT...12",
                           col.names.loc = 2)
 # Create chem.ids data.frame
 chem.ids <- data.frame("Chem.Lab.ID" = "745",


### PR DESCRIPTION
Please review the following updates to the README and DESCRIPTION files for maintainer transfer.

Major changes: 
* Addition of badge information
* Update the URL for the hex logo to go directly to CRAN page
* Update contributor list
* Change maintainer from @sedavid01 to @carolinering